### PR TITLE
removemany command renamed to multi-remove

### DIFF
--- a/src/commands/multi-remove.js
+++ b/src/commands/multi-remove.js
@@ -4,7 +4,7 @@ const ChannelRepository = require("../repositories/channel-repository");
 const { db } = require("../models/Channel");
 
 module.exports = {
-    name: 'removemany',
+    name: 'multi-remove',
     description: 'Removes multiple elements from the list',
     execute: async (message, args) => {
         let channel = message.channel;


### PR DESCRIPTION
PR for #56 

1. `removemany` command changed to  `multi-remove`
2. Same change made to filename