### PR TITLE
Fixed ping command issue

### DIFF
--- a/src/commands/ping.js
+++ b/src/commands/ping.js
@@ -8,7 +8,7 @@ module.exports = {
       const m = await message.channel.send("Please wait...");
       let embed = new Discord.MessageEmbed()
         .addField("⌛ Latency", `**${m.createdTimestamp -  message.createdTimestamp}ms**`)
-        .addField("💓 API", `**${Math.floor(client.ws.ping)}ms**`)
+        .addField("💓 API", `**${Math.floor(message.client.ws.ping)}ms**`)
         .setAuthor(message.author.username, message.author.displayAvatarURL)
         .setColor("RANDOM")
         .setTimestamp();


### PR DESCRIPTION
Resolves #110 

The exception was thrown because client was not defined inside **ping.js** scope.
I found inside **discord.js** docs that **Message** class has a read-only **client** property.