### PR TITLE
Fix reacts for poll with no time limit.

### DIFF
--- a/src/commands/poll.js
+++ b/src/commands/poll.js
@@ -76,6 +76,8 @@ module.exports = {
         channel.send(embed).then(async (pollMessage) => {
             // If no time limit was set for the poll, just exit without doing anything to collect results.
             if (pollDuration === 0) {
+                // Just provide the initial emoji reacts and exit.
+                emojiList.forEach((e) => pollMessage.react(e))
                 return
             }
 


### PR DESCRIPTION
After this change, polls with no time limit will now have the proper initial reacts available for voting.

Closes #122 

Signed-off-by: rgroves <rwgdev@gmail.com>