### PR TITLE
All configurable settings are now referenced via the config object.

### DIFF
--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -1,5 +1,5 @@
+const config = require('../config')
 const Util = require('../utils/utils.js')
-require('dotenv').config()
 
 module.exports = {
     name: 'help',
@@ -36,7 +36,7 @@ module.exports = {
         let msg = commands
             .map(
                 ([syntax, description]) =>
-                    `**${process.env.PREFIX}${syntax}** - ${description}`
+                    `**${config.prefix}${syntax}** - ${description}`
             )
             .join('\n')
         let embededMessage = Util.embedMessage(

--- a/src/config/.env.example
+++ b/src/config/.env.example
@@ -1,3 +1,10 @@
+################################################################################
+# Configuration Instructions
+################################################################################
+# All configuration should be set in this .env file. The only environment
+# variable you'll need to set external to this config file is the NODE_ENV to
+# set what environment you are running in (development/production).
+#
 # Uncomment any setting to override or leave commented to accept listed default.
 
 ################################################################################
@@ -77,3 +84,19 @@ DB_AUTH_DB=
 # Configuration for Web-based MongoDB Admin Interface
 MONGO_EXPRESS_USER=
 MONGO_EXPRESS_KEY=
+
+################################################################################
+# !!! EXPERIMENTAL FEATURES !!!
+################################################################################
+# The settings below are for experimental, not fully-baked, and/or untested
+# beta features.
+################################################################################
+# Encryption Key
+# The 32-character (256-bit) key to be used when encrypting list items in the
+# database.
+ENCRYPTION_KEY=
+
+# Encryption Key
+# The 16-character (128-bit) initialization vector to be used when encrypting
+# list items in the database.
+ENCRYPTION_IV=

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -6,6 +6,8 @@ if (result.error) throw result.error // Throw an error if it failed to load the 
 const {
     PREFIX: prefix = '$',
     BOT_TOKEN: botToken,
+    ENCRYPTION_KEY: encryptionKey,
+    ENCRYPTION_IV: encryptionIV,
     LOCAL_DB_SCHEME = 'mongodb',
     LOCAL_DB_USER,
     LOCAL_DB_PASSWORD,
@@ -65,4 +67,6 @@ module.exports = {
     botToken,
     devMongoUrl,
     productionMongoURL,
+    encryptionKey,
+    encryptionIV,
 }

--- a/src/events/message.js
+++ b/src/events/message.js
@@ -1,12 +1,9 @@
-const { prefix } = require('../config')
+const config = require('../config')
 
 module.exports = async (client, message) => {
-    if (!message.content.startsWith(prefix) || message.author.bot) return
+    if (!message.content.startsWith(config.prefix) || message.author.bot) return
 
-    let args = message.content
-        .slice(process.env.PREFIX.length)
-        .trim()
-        .split(/ +/)
+    let args = message.content.slice(config.prefix.length).trim().split(/ +/)
     const command = args.shift().toLowerCase()
 
     if (!client.commands.has(command)) return

--- a/src/utils/encrypt.js
+++ b/src/utils/encrypt.js
@@ -1,22 +1,24 @@
 /*
 const crypto = require('crypto')
+const config = require('../config')
 
 const algorithm = 'aes-256-cbc' // use the aes256 encryption algorithm
-const key = process.env.KEY
-// const key = 'uqB2&:pQ"4-5KVTJ@&-#*"LgQ2KBGQyn'
-const iv = process.env.IV
-// const iv = 'bz-qG-U*"6tz87;G'
-// key has to be 32 chars long
-// iv has to be 16 chars long
 
-if (key.length !== 32 || iv.length !==) {
+// config.encryptionKey has to be 32 chars long
+// config.encryptionIV has to be 16 chars long
+/*
+if (config.encryptionKey.length !== 32 || config.encryptionIV.length !==) {
 console.error("Key and IV lengths are invalid")
 } 
 
 // eslint-disable-next-line no-unused-vars
 let encrypt = (schema, options) => {
     schema.pre('save', { document: true, query: false }, function func(next) {
-        let cipher = crypto.createCipheriv(algorithm, Buffer.from(key), iv)
+        let cipher = crypto.createCipheriv(
+            algorithm,
+            Buffer.from(config.encryptionKey),
+            config.encryptionIV
+        )
         let encrypted = cipher.update(this.items[this.items.length - 1].content)
         encrypted = Buffer.concat([encrypted, cipher.final()]).toString(
             'base64'
@@ -35,8 +37,8 @@ let decrypt = (schema, options) => {
             let encryptedText = result.items[i].content
             let decipher = crypto.createDecipheriv(
                 algorithm,
-                Buffer.from(key),
-                iv
+                Buffer.from(config.encryptionKey),
+                config.encryptionIV
             )
             let decrypted = decipher.update(encryptedText, 'base64')
             decrypted = Buffer.concat([decrypted, decipher.final()])


### PR DESCRIPTION
This change was a refactor, making it so that all configuration settings are being referenced from the main config object (instead of using `process.env` directly). The only reference to `process.env` left in place (outside of `src/utils/config`) is the reference to `process.env.NODE_ENV` which is considered a true environment setting and not a bot specific configuration setting.

Also of note, I added notes and an "experimental/beta section" to the `src/config/.example.env` for the settings related to the not yet working encryption feature, but figured those should be included in this change as well since I modified how it was going after the setting variables for the encryption key and initialization vector. Whoever finishes out the encryption work, once it is stable and working, should probably modify the `src/config/.example.env` to remove the "experimental" section comments and make those officially support settings.

Closes #133

Signed-off-by: rgroves <rwgdev@gmail.com>