### PR TITLE
Fix #147 empty arguments bug in 'add' and 'remove' commands

### DIFF
--- a/src/commands/add.js
+++ b/src/commands/add.js
@@ -5,6 +5,8 @@ const easterEggCheck = require('./add-eggs').check
 
 module.exports = {
     name: 'add',
+    min_args: 1,
+    usage: "<content>",
     description: 'Add an element to the list',
     execute: async (message, args) => {
         let item = args.join(' ')

--- a/src/commands/add.js
+++ b/src/commands/add.js
@@ -6,7 +6,7 @@ const easterEggCheck = require('./add-eggs').check
 module.exports = {
     name: 'add',
     min_args: 1,
-    usage: "<content>",
+    usage: '<element>',
     description: 'Add an element to the list',
     execute: async (message, args) => {
         let item = args.join(' ')

--- a/src/commands/multi-add.js
+++ b/src/commands/multi-add.js
@@ -5,7 +5,7 @@ const ChannelRepository = require('../repositories/channel-repository')
 module.exports = {
     name: 'multi-add',
     min_args: 1,
-    usage: "<content_1> <content_2> ... <content_n>",
+    usage: '<element_1> <element_2> ... <element_n>',
     description: 'Add multiple elements to the list',
     execute: async (message, args) => {
         let item = [...args]

--- a/src/commands/multi-add.js
+++ b/src/commands/multi-add.js
@@ -4,8 +4,9 @@ const ChannelRepository = require('../repositories/channel-repository')
 
 module.exports = {
     name: 'multi-add',
+    min_args: 1,
+    usage: "<content_1> <content_2> ... <content_n>",
     description: 'Add multiple elements to the list',
-
     execute: async (message, args) => {
         let item = [...args]
 

--- a/src/commands/multi-remove.js
+++ b/src/commands/multi-remove.js
@@ -3,6 +3,8 @@ const ChannelRepository = require('../repositories/channel-repository')
 
 module.exports = {
     name: 'multi-remove',
+    min_args: 2,
+    usage: "<start_index> <end_index>",
     description: 'Removes multiple elements from the list',
     execute: async (message, args) => {
         let { channel } = message

--- a/src/commands/multi-remove.js
+++ b/src/commands/multi-remove.js
@@ -4,7 +4,7 @@ const ChannelRepository = require('../repositories/channel-repository')
 module.exports = {
     name: 'multi-remove',
     min_args: 2,
-    usage: "<start_index> <end_index>",
+    usage: '<start_index> <end_index>',
     description: 'Removes multiple elements from the list',
     execute: async (message, args) => {
         let { channel } = message

--- a/src/commands/remove.js
+++ b/src/commands/remove.js
@@ -3,6 +3,8 @@ const ChannelRepository = require('../repositories/channel-repository')
 
 module.exports = {
     name: 'remove',
+    min_args: 1,
+    usage: '<index>',
     description: 'Removes an element from the list',
     execute: async (message, args) => {
         let { channel } = message

--- a/src/events/message.js
+++ b/src/events/message.js
@@ -1,5 +1,6 @@
-const config = require('../config');
-const Util = require('../utils/utils');
+const config = require('../config')
+const Style = require('../utils/messageStyle')
+const Util = require('../utils/utils')
 
 module.exports = async (client, message) => {
     if (!message.content.startsWith(config.prefix) || message.author.bot) return
@@ -9,14 +10,16 @@ module.exports = async (client, message) => {
 
     if (!client.commands.has(commandName)) return
 
-    const command = client.commands.get(commandName);
+    const command = client.commands.get(commandName)
 
-    if (command.hasOwnProperty("min_args") && command.min_args > args.length) {
+    if (command.hasOwnProperty('min_args') && command.min_args > args.length) {
         let embeddedMessage = Util.embedMessage(
-            'You didn\'t provide enough arguments!',
+            "You didn't provide enough arguments!",
             message.author,
             '0xffff00',
-            `The correct usage would be: ${config.prefix}${commandName} ${command.usage}`
+            Style.warn(
+                `The correct usage would be: \n${config.prefix}${commandName} ${command.usage}`
+            )
         )
         return message.channel.send(embeddedMessage)
     }

--- a/src/events/message.js
+++ b/src/events/message.js
@@ -11,7 +11,7 @@ module.exports = async (client, message) => {
 
     const command = client.commands.get(commandName);
 
-    if (command.min_args > args.length) {
+    if (command.hasOwnProperty("min_args") && command.min_args > args.length) {
         let embeddedMessage = Util.embedMessage(
             'You didn\'t provide enough arguments!',
             message.author.tag,

--- a/src/events/message.js
+++ b/src/events/message.js
@@ -12,7 +12,10 @@ module.exports = async (client, message) => {
 
     const command = client.commands.get(commandName)
 
-    if (command.hasOwnProperty('min_args') && command.min_args > args.length) {
+    if (
+        Object.prototype.hasOwnProperty.call(command, 'min_args') &&
+        command.min_args > args.length
+    ) {
         let embeddedMessage = Util.embedMessage(
             "You didn't provide enough arguments!",
             message.author,
@@ -21,7 +24,8 @@ module.exports = async (client, message) => {
                 `The correct usage would be: \n${config.prefix}${commandName} ${command.usage}`
             )
         )
-        return message.channel.send(embeddedMessage)
+        message.channel.send(embeddedMessage)
+        return
     }
 
     try {

--- a/src/events/message.js
+++ b/src/events/message.js
@@ -14,7 +14,7 @@ module.exports = async (client, message) => {
     if (command.hasOwnProperty("min_args") && command.min_args > args.length) {
         let embeddedMessage = Util.embedMessage(
             'You didn\'t provide enough arguments!',
-            message.author.tag,
+            message.author,
             '0xffff00',
             `The correct usage would be: ${config.prefix}${commandName} ${command.usage}`
         )

--- a/src/events/message.js
+++ b/src/events/message.js
@@ -1,15 +1,28 @@
-const config = require('../config')
+const config = require('../config');
+const Util = require('../utils/utils');
 
 module.exports = async (client, message) => {
     if (!message.content.startsWith(config.prefix) || message.author.bot) return
 
     let args = message.content.slice(config.prefix.length).trim().split(/ +/)
-    const command = args.shift().toLowerCase()
+    const commandName = args.shift().toLowerCase()
 
-    if (!client.commands.has(command)) return
+    if (!client.commands.has(commandName)) return
+
+    const command = client.commands.get(commandName);
+
+    if (command.min_args > args.length) {
+        let embeddedMessage = Util.embedMessage(
+            'You didn\'t provide enough arguments!',
+            message.author.tag,
+            '0xffff00',
+            `The correct usage would be: ${config.prefix}${commandName} ${command.usage}`
+        )
+        return message.channel.send(embeddedMessage)
+    }
 
     try {
-        client.commands.get(command).execute(message, args)
+        command.execute(message, args)
     } catch (error) {
         console.error(error)
         message.reply('There was an error trying to execute that command!')


### PR DESCRIPTION
Closes #147 
- Fixed a bug when user calls "add", "multi-add", "remove" and "multi-remove" commands without providing enough arguments.
- Bot now replies with a usage hint if user calls any of the above commands incorrectly.
     