### PR TITLE
$help command outputs all existing commands

### DIFF
--- a/src/commands/demote.js
+++ b/src/commands/demote.js
@@ -4,6 +4,7 @@ const Util = require('../utils/utils.js')
 module.exports = {
     name: 'demote',
     description: 'Remove a user from admin of ListBot',
+    usage: '<@user>',
     execute: async (message) => {
         // check if user promoting is admin
         const guildID = message.guild.id

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -1,7 +1,7 @@
+const fs = require('fs')
 const config = require('../config')
 const Util = require('../utils/utils.js')
 const Style = require('../utils/messageStyle.js')
-const fs = require('fs')
 
 const COMMANDS_FOLDER = './src/commands'
 
@@ -14,11 +14,16 @@ module.exports = {
         // [syntax, description]
         let commands = []
 
-        fs.readdirSync(COMMANDS_FOLDER).forEach(file => {
-            const command = require('./' + file)
-            if (!command.hasOwnProperty('name') || !command.hasOwnProperty('description')) return
+        fs.readdirSync(COMMANDS_FOLDER).forEach((file) => {
+            // eslint-disable-next-line import/no-dynamic-require,global-require
+            const command = require(`./${file}`)
+            if (
+                !Object.prototype.hasOwnProperty.call(command, 'name') ||
+                !Object.prototype.hasOwnProperty.call(command, 'description')
+            )
+                return
 
-            const usage = (command.usage != null) ? ' ' + command.usage : ''
+            const usage = command.usage != null ? ` ${command.usage}` : ''
             commands.push([`${command.name}${usage}`, command.description])
         })
 

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -1,6 +1,9 @@
 const config = require('../config')
 const Util = require('../utils/utils.js')
 const Style = require('../utils/messageStyle.js')
+const fs = require('fs')
+
+const COMMANDS_FOLDER = './src/commands'
 
 module.exports = {
     name: 'help',
@@ -9,32 +12,15 @@ module.exports = {
         let { channel } = message
 
         // [syntax, description]
-        let commands = [
-            ['add {element}', 'to add an element to the list'],
-            [
-                'multi-add {element} {element}',
-                'to add multiple elements to the list',
-            ],
-            ['remove {element}', 'to remove an element from the list'],
-            [
-                'multi-remove {element} {element}',
-                'to remove multiple elements from the list',
-            ],
-            ['list', 'to list every element on the list'],
-            ['random', 'gets a random element from the list'],
-            [
-                'poll {active_time_in_minutes} [{number_of_items}]',
-                'creates a poll on the channel for 2 to 9 random elements. ' +
-                    'Uses 5 elements by default. If you want a poll with custom number of elements ' +
-                    'with no poll time limit, set the time as 0.',
-            ],
-            ['log', "gets the bot's log"],
-            [
-                'remind {time_in_minutes} {element}',
-                'to add an item and be reminded in n minutes',
-            ],
-            ['help', 'to see this message'],
-        ]
+        let commands = []
+
+        fs.readdirSync(COMMANDS_FOLDER).forEach(file => {
+            const command = require('./' + file)
+            if (!command.hasOwnProperty('name') || !command.hasOwnProperty('description')) return
+
+            const usage = (command.usage != null) ? ' ' + command.usage : ''
+            commands.push([`${command.name}${usage}`, command.description])
+        })
 
         let msg = commands
             .map(

--- a/src/commands/poll.js
+++ b/src/commands/poll.js
@@ -11,6 +11,7 @@ const DEFAULT_ITEMS_COUNT = 5
 module.exports = {
     name: 'poll',
     description: `Generates a Poll from ${MIN_ITEMS_COUNT} to ${MAX_ITEMS_COUNT} random elements on the list`,
+    usage: `<time_in_minutes> [nb_items=${DEFAULT_ITEMS_COUNT}]`,
     execute: async (
         message,
         [time, requestedPollCount = DEFAULT_ITEMS_COUNT]

--- a/src/commands/promote.js
+++ b/src/commands/promote.js
@@ -4,6 +4,7 @@ const Util = require('../utils/utils.js')
 module.exports = {
     name: 'promote',
     description: 'Promote a user into an admin of ListBot',
+    usage: '<@user>',
     execute: async (message) => {
         // check if user promoting is admin
         const guildID = message.guild.id

--- a/src/commands/remind.js
+++ b/src/commands/remind.js
@@ -3,6 +3,7 @@ const Style = require('../utils/messageStyle.js')
 
 module.exports = {
     name: 'remind',
+    usage: '<time_in_seconds>',
     description: 'Bot reminds of an item in channel after specific time',
     execute: async (message, [minutes, ...elements]) => {
         let { channel } = message


### PR DESCRIPTION
Closes #160 

This PR modifies the `$help` with the use of `fs` package, to read all existing files in `./src/commands`.

For each file, if a `name` and `description` property exist, the file is considered valid for a command and added to the array of printed help.

If the optional `usage` property exists, it is used to provide information on which arguments are expected for the command to be run properly.

The PR also modifies the different commands to add `usage` when necessary.

The result on local testing:
```bash
$add <element> = "Add an element to the list"
$clear = "Remove all element in the list for the specific channel."
$demote <@user> = "Remove a user from admin of ListBot"
$help = "Gets the bot commands"
$list = "Lists all the elements of the list"
$log = "Gets info from the bot"
$multi-add <element_1> <element_2> ... <element_n> = "Add multiple elements to the list"
$multi-remove <start_index> <end_index> = "Removes multiple elements from the list"
$ping = "Check the bot latency"
$poll <time_in_minutes> [nb_items=5] = "Generates a Poll from 2 to 9 random elements on the list"
$promote <@user> = "Promote a user into an admin of ListBot"
$random = "Gets a random element from the list"
$remind <time_in_seconds> = "Bot reminds of an item in channel after specific time"
$remove <index> = "Removes an element from the list"
```