### PR TITLE
Change argument delimiter for $multi-add command

### DIFF
--- a/src/commands/multi-add.js
+++ b/src/commands/multi-add.js
@@ -7,9 +7,10 @@ module.exports = {
     name: 'multi-add',
     min_args: 1,
     usage: '<element_1>;<element_2>;...;<element_n>',
+    delimiter: ';',
     description: 'Add multiple elements to the list',
     execute: async (message, args) => {
-        let item = [...args].join(' ').split(';')
+        let item = [...args]
 
         let { channel } = message
 

--- a/src/commands/multi-add.js
+++ b/src/commands/multi-add.js
@@ -6,10 +6,10 @@ const ChannelRepository = require('../repositories/channel-repository')
 module.exports = {
     name: 'multi-add',
     min_args: 1,
-    usage: '<element_1> <element_2> ... <element_n>',
+    usage: '<element_1>;<element_2>;...;<element_n>',
     description: 'Add multiple elements to the list',
     execute: async (message, args) => {
-        let item = [...args]
+        let item = [...args].join(' ').split(';')
 
         let { channel } = message
 

--- a/src/commands/multi-add.js
+++ b/src/commands/multi-add.js
@@ -17,7 +17,7 @@ module.exports = {
 
         for (const instance of item) {
             let newItem = new Item({
-                content: instance,
+                content: instance.trim(),
                 author: message.author.tag,
             })
 
@@ -26,7 +26,7 @@ module.exports = {
 
         dbChannel.save()
 
-        const description = item.map((msg, i) => `${i + 1}. ${msg}`).join('\n')
+        const description = item.map((msg, i) => `${i + 1}. ${msg.trim()}`).join('\n')
 
         let embeddedMessage = Util.embedMessage(
             `Added ${item.length} item(s) to \`${channel.name}\`'s List`,

--- a/src/commands/multi-add.js
+++ b/src/commands/multi-add.js
@@ -27,7 +27,9 @@ module.exports = {
 
         dbChannel.save()
 
-        const description = item.map((msg, i) => `${i + 1}. ${msg.trim()}`).join('\n')
+        const description = item
+            .map((msg, i) => `${i + 1}. ${msg.trim()}`)
+            .join('\n')
 
         let embeddedMessage = Util.embedMessage(
             `Added ${item.length} item(s) to \`${channel.name}\`'s List`,

--- a/src/events/message.js
+++ b/src/events/message.js
@@ -5,7 +5,10 @@ const Util = require('../utils/utils')
 module.exports = async (client, message) => {
     if (!message.content.startsWith(config.prefix) || message.author.bot) return
 
-    const splitMessage = message.content.slice(config.prefix.length).trim().split(/ /)
+    const splitMessage = message.content
+        .slice(config.prefix.length)
+        .trim()
+        .split(/ /)
     let [commandName, args] = [splitMessage.shift(), splitMessage.join(' ')]
 
     if (!client.commands.has(commandName)) return

--- a/src/events/message.js
+++ b/src/events/message.js
@@ -5,12 +5,13 @@ const Util = require('../utils/utils')
 module.exports = async (client, message) => {
     if (!message.content.startsWith(config.prefix) || message.author.bot) return
 
-    let args = message.content.slice(config.prefix.length).trim().split(/ +/)
-    const commandName = args.shift().toLowerCase()
+    const splitMessage = message.content.slice(config.prefix.length).trim().split(/ /)
+    let [commandName, args] = [splitMessage.shift(), splitMessage.join(' ')]
 
     if (!client.commands.has(commandName)) return
 
     const command = client.commands.get(commandName)
+    if (args != null) args = args.split(command.delimiter ?? / +/)
 
     if (
         Object.prototype.hasOwnProperty.call(command, 'min_args') &&


### PR DESCRIPTION
Closes #163 

This PR changes the way the commands work:
- The message splits at spaces
- First element is command name, the rest is joined again with `' '`, put into the `args` variable. At this point, we have two strings `commandName` and `args`
- It loads the command with the name, and then checks for its `delimiter` property. Using the `??` operator, the default fallback is `/ +/` (old delimiter).
- The multi-add command has `delimiter` set to `;`, the other commands don't have this property (it uses the fallback delimiter).

The PR updates the usage description of the `multi-add` command.