### PR TITLE
Send multiple messages if list is too long

### DIFF
--- a/src/commands/list.js
+++ b/src/commands/list.js
@@ -32,7 +32,7 @@ module.exports = {
 
         function send() {
             if (fields.length === 0) return
-            
+
             let embeddedMessage = Util.embedMessage(
                 `List for \`${channelName}\``,
                 message.author,

--- a/src/commands/list.js
+++ b/src/commands/list.js
@@ -31,6 +31,8 @@ module.exports = {
         let size = 0
 
         function send() {
+            if (fields.length === 0) return
+            
             let embeddedMessage = Util.embedMessage(
                 `List for \`${channelName}\``,
                 message.author,

--- a/src/commands/list.js
+++ b/src/commands/list.js
@@ -2,7 +2,7 @@ let Util = require('../utils/utils.js')
 const Style = require('../utils/messageStyle.js')
 const ChannelRepository = require('../repositories/channel-repository')
 
-const MAX_EMBED_SIZE = 1900
+const MAX_EMBED_SIZE = 1800
 
 module.exports = {
     name: 'list',


### PR DESCRIPTION
Closes #161 

This PR modifies the way `$list` work:
- Instead of using `map` to create the `fields` array, it iterates through the array
- Using a variable named `size` and a limit (set to 1800 to avoid problems, since the embed uses the channel name (max 100 characters) and the user name (max 32 characters) along with other data), we add lines to the embedded message
- If the current line makes the message grow over the limit, the message is sent **without** it, and the line is added in the next message