### PR TITLE
Make commands case-insensitive.

### DIFF
--- a/src/events/message.js
+++ b/src/events/message.js
@@ -9,7 +9,10 @@ module.exports = async (client, message) => {
         .slice(config.prefix.length)
         .trim()
         .split(/ /)
-    let [commandName, args] = [splitMessage.shift(), splitMessage.join(' ')]
+    let [commandName, args] = [
+        splitMessage.shift().toLowerCase(),
+        splitMessage.join(' '),
+    ]
 
     if (!client.commands.has(commandName)) return
 


### PR DESCRIPTION
This is a fix which returns case-insensitivity back to bot commands entered by a user which was lost in #164

Closes #169 