### PR TITLE
Fix how reminder text is joined.

### DIFF
--- a/src/commands/remind.js
+++ b/src/commands/remind.js
@@ -30,7 +30,7 @@ module.exports = {
             return
         }
 
-        let item = elements.map((curItem) => `${curItem} `) // TODO should this be a join?
+        let item = elements.join(' ')
 
         if (item === '') {
             let embeddedMessage = Util.embedMessage(


### PR DESCRIPTION
With this fix the code for an empty reminder is triggered correctly and the reminder text is no longer treated as separate delimited items.

Closes #173 